### PR TITLE
refactor : 랜덤 매칭 중복 신청 쿼리 수정 및 결제 이후 로직 추가

### DIFF
--- a/boot/api/src/main/java/com/clip/api/matching/service/RandomMatchingOrderService.java
+++ b/boot/api/src/main/java/com/clip/api/matching/service/RandomMatchingOrderService.java
@@ -68,18 +68,18 @@ public class RandomMatchingOrderService {
         });
 
         // 모든 모임에 4명씩 채워졌는지 확인
-        boolean allMeetingsHaveThreeMembers = randomMatchingCapacities.stream()
+        boolean allMeetingsHaveFourMembers = randomMatchingCapacities.stream()
                 .allMatch(capacity -> currentParticipantsMap.get(capacity.getRandomMatching().getId()) >= MIN_RANDOM_MATHING_CAPACITY);
 
         RandomMatchingCapacity selectedCapacity;
 
-        if (!allMeetingsHaveThreeMembers) {
+        if (!allMeetingsHaveFourMembers) {
             // 4명 미만인 모임들 중에서 순서대로 선택 (가용 인원이 많은 순으로 정렬된 상태)
             selectedCapacity = randomMatchingCapacities.stream()
                     .filter(capacity -> currentParticipantsMap.get(capacity.getRandomMatching().getId()) < MIN_RANDOM_MATHING_CAPACITY
                             && capacity.getAvailableCapacity() > MIN_AVAILABLE_CAPACITY)
                     .findFirst()
-                    .orElseThrow(() -> new MatchingFailedException("3명 미만인 모임이 없거나 모든 모임이 가득 찼습니다."));
+                    .orElseThrow(() -> new MatchingFailedException("4명 미만인 모임이 없거나 모든 모임이 가득 찼습니다."));
         } else {
             // 모든 모임에 4명씩 채워진 경우, 참여자 수가 가장 적은 모임 선택
             selectedCapacity = randomMatchingCapacities.stream()

--- a/boot/api/src/main/java/com/clip/api/payment/service/PaymentServiceFacade.java
+++ b/boot/api/src/main/java/com/clip/api/payment/service/PaymentServiceFacade.java
@@ -30,7 +30,7 @@ public class PaymentServiceFacade {
                         .build()
                 );
                 log.info("paymentObject info: {}", paymentObject.toString());
-                userPaymentService.updateRandomOrderStatus(userId, paymentObject);
+                userPaymentService.updateRandomStatus(userId, paymentObject);
             }
             case ONETHING -> {
                 OneThingOrder oneThingOrder = userPaymentService.findOneThingOrder(userId, paymentDto.getOrderId());

--- a/boot/api/src/main/java/com/clip/api/payment/service/UserPaymentService.java
+++ b/boot/api/src/main/java/com/clip/api/payment/service/UserPaymentService.java
@@ -3,6 +3,9 @@ package com.clip.api.payment.service;
 import com.clip.api.payment.feign.dto.PaymentObject;
 import com.clip.api.payment.mapper.TossPaymentMapper;
 import com.clip.api.payment.service.event.PaymentExceptionEvent;
+import com.clip.matching.entity.MatchingStatus;
+import com.clip.matching.entity.UserRandomMatching;
+import com.clip.matching.service.UserRandomMatchingService;
 import com.clip.order.entity.OneThingOrder;
 import com.clip.order.entity.OneThingOrderStatus;
 import com.clip.order.entity.RandomOrder;
@@ -27,6 +30,7 @@ public class UserPaymentService {
 
     private final OneThingOrderService oneThingOrderService;
     private final RandomOrderService randomOrderService;
+    private final UserRandomMatchingService userRandomMatchingService;
     private final ApplicationEventPublisher eventPublisher;
 
     public OneThingOrder findOneThingOrder(long userId, UUID orderId) {
@@ -51,7 +55,7 @@ public class UserPaymentService {
     }
 
     @Transactional
-    public void updateRandomOrderStatus(long userId, PaymentObject paymentObject) {
+    public void updateRandomStatus(long userId, PaymentObject paymentObject) {
         eventPublisher.publishEvent(PaymentExceptionEvent.builder()
                 .paymentKey(paymentObject.getPaymentKey())
                 .build()
@@ -61,5 +65,8 @@ public class UserPaymentService {
         TossPayment tossPayment = tossPaymentMapper.toTossPayment(paymentObject);
         randomOrder.updateStatus(RandomOrderStatus.DONE);
         randomOrder.addTossPayment(tossPayment);
+
+        UserRandomMatching userRandomMatching = userRandomMatchingService.findUserRandomMatching(userId, randomOrder.getId());
+        userRandomMatching.updateStatus(MatchingStatus.CONFIRMED);
     }
 }

--- a/boot/api/src/test/java/boot/api/com/clip/api/matching/service/RandomMatchingOrderServiceTest.java
+++ b/boot/api/src/test/java/boot/api/com/clip/api/matching/service/RandomMatchingOrderServiceTest.java
@@ -218,7 +218,7 @@ public class RandomMatchingOrderServiceTest {
                     .user(user)
                     .randomMatching(randomMatching)
                     .myOneThingContent("테스트 주제")
-                    .matchingStatus(MatchingStatus.APPLIED)
+                    .matchingStatus(MatchingStatus.CONFIRMED)
                     .build();
 
             userRandomMatchingRepository.save(userRandomMatching);

--- a/data/core-data/src/main/java/com/clip/global/exception/ResourceNotFoundException.java
+++ b/data/core-data/src/main/java/com/clip/global/exception/ResourceNotFoundException.java
@@ -6,6 +6,10 @@ public class ResourceNotFoundException extends RuntimeException {
         super(String.format("Resource %s with id %d not found", resourceName, id));
     }
 
+    public ResourceNotFoundException(String resourceName, Long id, Long relatedId) {
+        super(String.format("Resource %s with id %d not found, related to id %d", resourceName, id, relatedId));
+    }
+
     public ResourceNotFoundException(String resourceName, String identifier) {
         super(String.format("Resource %s with identifier %s not found", resourceName, identifier));
     }

--- a/data/core-data/src/main/java/com/clip/matching/entity/UserRandomMatching.java
+++ b/data/core-data/src/main/java/com/clip/matching/entity/UserRandomMatching.java
@@ -54,4 +54,8 @@ public class UserRandomMatching extends BaseEntity {
         this.matchingStatus = matchingStatus;
         this.isNoticeRead = isNoticeRead;
     }
+
+    public void updateStatus(MatchingStatus matchingStatus) {
+        this.matchingStatus = matchingStatus;
+    }
 }

--- a/data/core-data/src/main/java/com/clip/matching/repository/UserMatchingRepository.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/UserMatchingRepository.java
@@ -43,9 +43,10 @@ public interface UserMatchingRepository extends JpaRepository<UserOneThingMatchi
         from UserRandomMatching urm
         join urm.randomMatching rm
         left join RandomMatchingReview rmr on rmr.randomMatching.id = rm.id and rmr.user.id = :userId
-        where (:matchingStatus is null or urm.matchingStatus = :matchingStatus)
-        and (:lastMeetingTime is null or urm.randomMatching.meetingTime < :lastMeetingTime)
-        and urm.user.id = :userId
+        where urm.user.id = :userId
+          and urm.matchingStatus != 'APPLIED'
+          and (:matchingStatus is null or urm.matchingStatus = :matchingStatus)
+          and (:lastMeetingTime is null or rm.meetingTime < :lastMeetingTime)
         order by urm.randomMatching.meetingTime desc
         """)
     List<MatchingProjectionDto> findAllMatchingsByStatus(

--- a/data/core-data/src/main/java/com/clip/matching/repository/UserRandomMatchingRepository.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/UserRandomMatchingRepository.java
@@ -81,6 +81,8 @@ public interface UserRandomMatchingRepository extends JpaRepository<UserRandomMa
             from UserRandomMatching u
             where u.user.id = :userId
             and u.randomMatching.meetingTime = :meetingTime
+            and u.matchingStatus = :matchingStatus
             """)
-    Optional<UserRandomMatching> findUserRandomMatching(@Param("userId") long userId, @Param("meetingTime") LocalDateTime meetingTime);
+    Optional<UserRandomMatching> findUserRandomMatching(@Param("userId") long userId, @Param("meetingTime") LocalDateTime meetingTime,
+                                                        @Param("matchingStatus") MatchingStatus matchingStatus);
 }

--- a/data/core-data/src/main/java/com/clip/matching/repository/UserRandomMatchingRepository.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/UserRandomMatchingRepository.java
@@ -85,4 +85,12 @@ public interface UserRandomMatchingRepository extends JpaRepository<UserRandomMa
             """)
     Optional<UserRandomMatching> findUserRandomMatching(@Param("userId") long userId, @Param("meetingTime") LocalDateTime meetingTime,
                                                         @Param("matchingStatus") MatchingStatus matchingStatus);
+
+    @Query("""
+            select u
+            from UserRandomMatching u
+            where u.user.id = :userId
+            and u.randomOrder.id = :randomOrderId
+            """)
+    Optional<UserRandomMatching> findUserRandomMatching(@Param("userId") long userId, @Param("randomOrderId") Long randomOrderId);
 }

--- a/data/core-data/src/main/java/com/clip/matching/service/UserRandomMatchingService.java
+++ b/data/core-data/src/main/java/com/clip/matching/service/UserRandomMatchingService.java
@@ -1,5 +1,6 @@
 package com.clip.matching.service;
 
+import com.clip.matching.entity.MatchingStatus;
 import com.clip.matching.entity.UserRandomMatching;
 import com.clip.matching.repository.UserRandomMatchingRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,6 @@ public class UserRandomMatchingService {
     }
 
     public boolean isDuplicatedMatching(long userId, LocalDateTime meetingTime) {
-        return userRandomMatchingRepository.findUserRandomMatching(userId, meetingTime).isPresent();
+        return userRandomMatchingRepository.findUserRandomMatching(userId, meetingTime, MatchingStatus.CONFIRMED).isPresent();
     }
 }

--- a/data/core-data/src/main/java/com/clip/matching/service/UserRandomMatchingService.java
+++ b/data/core-data/src/main/java/com/clip/matching/service/UserRandomMatchingService.java
@@ -1,5 +1,6 @@
 package com.clip.matching.service;
 
+import com.clip.global.exception.ResourceNotFoundException;
 import com.clip.matching.entity.MatchingStatus;
 import com.clip.matching.entity.UserRandomMatching;
 import com.clip.matching.repository.UserRandomMatchingRepository;
@@ -27,5 +28,10 @@ public class UserRandomMatchingService {
 
     public boolean isDuplicatedMatching(long userId, LocalDateTime meetingTime) {
         return userRandomMatchingRepository.findUserRandomMatching(userId, meetingTime, MatchingStatus.CONFIRMED).isPresent();
+    }
+
+    public UserRandomMatching findUserRandomMatching(long userId, Long randomOrderId) {
+        return userRandomMatchingRepository.findUserRandomMatching(userId, randomOrderId)
+                .orElseThrow(() -> new ResourceNotFoundException("UserRandomMatching", userId, randomOrderId));
     }
 }


### PR DESCRIPTION
- 정책에 빠른 변수명 및 에러 메세지 수정 (3명 -> 4명)
- 랜덤 매칭 중복 신청 여부 조회 시, MatchingStatus가 CONFIRMED만 조회하도록 쿼리 수정
- 토스 결제 완료 시 랜덤 매칭 상태 변경하도록 수정
- 매칭 리스트 조회에서 랜덤 매칭일 경우, 신청 완료 상태는 조회하지 않도록 쿼리 수정