### PR TITLE
feat : 매칭 참여자 리스트 조회 API

### DIFF
--- a/boot/api/src/main/java/com/clip/api/docs/matching/MatchingReviewDocs.java
+++ b/boot/api/src/main/java/com/clip/api/docs/matching/MatchingReviewDocs.java
@@ -1,16 +1,17 @@
 package com.clip.api.docs.matching;
 
 import com.clip.api.matching.controller.dto.MatchingReviewDto;
+import com.clip.api.matching.controller.dto.MatchingType;
+import com.clip.api.matching.controller.dto.ParticipantsInfoDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "매칭 후기 관리", description = "매칭 후기 등록, 후기 작성 여부 조회 etc ")
 @RequestMapping("/reviews")
@@ -39,5 +40,23 @@ public interface MatchingReviewDocs {
             @PathVariable final Long matchingId,
             @PathVariable final String matchingType,
             @RequestBody final MatchingReviewDto request,
+            @AuthenticationPrincipal final UserDetails userDetails);
+
+    @Operation(
+            summary = "매칭 참여자 리스트 조회 API"
+            , description = """
+                    - 매칭 참여자 리스트를 조회합니다.
+                    - matchingType은 매칭 종류를 나타내며, 'RANDOM' 또는 'ONE_THING' 둘 중 하나로 보내주세요.
+                    - matchingId는 매칭의 고유 ID입니다. 내 모임에서 후기 작성하기 버튼을 누를 경우, 응답 필드에 보내드린 matchingId를 사용하여 해당 API를 호출해주세요.
+                   \s"""
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공"
+    )
+    @GetMapping("/{matchingId}/{matchingType}/participants")
+    List<ParticipantsInfoDto> getMatchingParticipants(
+            @PathVariable final Long matchingId,
+            @PathVariable final MatchingType matchingType,
             @AuthenticationPrincipal final UserDetails userDetails);
 }

--- a/boot/api/src/main/java/com/clip/api/docs/matching/MatchingReviewDocs.java
+++ b/boot/api/src/main/java/com/clip/api/docs/matching/MatchingReviewDocs.java
@@ -38,7 +38,7 @@ public interface MatchingReviewDocs {
     @PostMapping("/{matchingId}/{matchingType}")
     void createMatchingReview(
             @PathVariable final Long matchingId,
-            @PathVariable final String matchingType,
+            @PathVariable final MatchingType matchingType,
             @RequestBody final MatchingReviewDto request,
             @AuthenticationPrincipal final UserDetails userDetails);
 

--- a/boot/api/src/main/java/com/clip/api/matching/controller/MatchingReviewController.java
+++ b/boot/api/src/main/java/com/clip/api/matching/controller/MatchingReviewController.java
@@ -23,4 +23,13 @@ public class MatchingReviewController implements MatchingReviewDocs {
                 request
         );
     }
+
+    @Override
+    public List<ParticipantsInfoDto> getMatchingParticipants(Long matchingId, MatchingType matchingType, UserDetails userDetails) {
+        return userMatchingReviewService.getMatchingParticipants(
+                Long.parseLong(userDetails.getUsername()),
+                matchingId,
+                matchingType
+        );
+    }
 }

--- a/boot/api/src/main/java/com/clip/api/matching/controller/MatchingReviewController.java
+++ b/boot/api/src/main/java/com/clip/api/matching/controller/MatchingReviewController.java
@@ -2,10 +2,14 @@ package com.clip.api.matching.controller;
 
 import com.clip.api.docs.matching.MatchingReviewDocs;
 import com.clip.api.matching.controller.dto.MatchingReviewDto;
+import com.clip.api.matching.controller.dto.MatchingType;
+import com.clip.api.matching.controller.dto.ParticipantsInfoDto;
 import com.clip.api.matching.service.UserMatchingReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,7 +18,7 @@ public class MatchingReviewController implements MatchingReviewDocs {
     private final UserMatchingReviewService userMatchingReviewService;
 
     @Override
-    public void createMatchingReview(final Long matchingId, final String matchingType,
+    public void createMatchingReview(final Long matchingId, final MatchingType matchingType,
                                      final MatchingReviewDto request, final UserDetails userDetails) {
         userMatchingReviewService.saveMatchingReview(
                 Long.parseLong(userDetails.getUsername()),

--- a/boot/api/src/main/java/com/clip/api/matching/controller/dto/MatchingDto.java
+++ b/boot/api/src/main/java/com/clip/api/matching/controller/dto/MatchingDto.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class MatchingDto {
     private Long id;
+    private Long matchingId;
     private LocalDateTime meetingTime;
     private MatchingStatus matchingStatus;
     private String matchingType;
@@ -19,9 +20,10 @@ public class MatchingDto {
     private Boolean isReviewWritten;
 
     @Builder
-    public MatchingDto(Long id, LocalDateTime meetingTime, MatchingStatus matchingStatus,
+    public MatchingDto(Long id, Long matchingId, LocalDateTime meetingTime, MatchingStatus matchingStatus,
                        String matchingType, String myOneThingContent, Boolean isReviewWritten) {
         this.id = id;
+        this.matchingId = matchingId;
         this.meetingTime = meetingTime;
         this.matchingStatus = matchingStatus;
         this.matchingType = matchingType;

--- a/boot/api/src/main/java/com/clip/api/matching/controller/dto/ParticipantsInfoDto.java
+++ b/boot/api/src/main/java/com/clip/api/matching/controller/dto/ParticipantsInfoDto.java
@@ -1,0 +1,11 @@
+package com.clip.api.matching.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipantsInfoDto {
+    private long id;
+    private String nickname;
+}

--- a/boot/api/src/main/java/com/clip/api/matching/service/UserMatchingReviewService.java
+++ b/boot/api/src/main/java/com/clip/api/matching/service/UserMatchingReviewService.java
@@ -42,5 +42,22 @@ public class UserMatchingReviewService {
         final OneThingMatching oneThingMatching = matchingService.findOneThingMatching(matchingId);
         matchingReviewService.save(matchingReviewMapper.toOneThingMatchingReview(user, oneThingMatching, request));
     }
+
+    public List<ParticipantsInfoDto> getMatchingParticipants(final Long userId, final Long matchingId, final MatchingType matchingType) {
+        return switch (matchingType) {
+            case MatchingType.RANDOM ->
+                    matchingService.findRandomMatchingParticipants(matchingId).stream()
+                            .map(userMatching -> ParticipantsInfoDto.builder()
+                                    .id(userMatching.getUser().getId())
+                                    .nickname(userMatching.getUser().getNickname()).build())
+                            .toList();
+            case MatchingType.ONE_THING ->
+                matchingService.findOneThingMatchingParticipants(matchingId).stream()
+                        .map(userOneThingMatching -> ParticipantsInfoDto.builder()
+                                .id(userOneThingMatching.getUser().getId())
+                                .nickname(userOneThingMatching.getUser().getNickname()).build())
+                        .toList();
+        };
+    }
 }
 

--- a/boot/api/src/main/java/com/clip/api/matching/service/UserMatchingReviewService.java
+++ b/boot/api/src/main/java/com/clip/api/matching/service/UserMatchingReviewService.java
@@ -1,6 +1,8 @@
 package com.clip.api.matching.service;
 
 import com.clip.api.matching.controller.dto.MatchingReviewDto;
+import com.clip.api.matching.controller.dto.MatchingType;
+import com.clip.api.matching.controller.dto.ParticipantsInfoDto;
 import com.clip.api.matching.mapper.MatchingReviewMapper;
 import com.clip.matching.entity.OneThingMatching;
 import com.clip.matching.entity.RandomMatching;
@@ -11,6 +13,8 @@ import com.clip.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,11 +27,10 @@ public class UserMatchingReviewService {
 
     @Transactional
     public void saveMatchingReview(final Long userId, final Long matchingId,
-                                   final String matchingType, final MatchingReviewDto request) {
-        switch (matchingType.toUpperCase()) {
-            case "RANDOM" -> handleRandomMatchingReview(userId, matchingId, request);
-            case "ONE_THING" -> handleOneThingMatchingReview(userId, matchingId, request);
-            default -> throw new IllegalArgumentException("존재하지 않는 서비스 명입니다 : " + matchingType);
+                                   final MatchingType matchingType, final MatchingReviewDto request) {
+        switch (matchingType) {
+            case MatchingType.RANDOM -> handleRandomMatchingReview(userId, matchingId, request);
+            case MatchingType.ONE_THING -> handleOneThingMatchingReview(userId, matchingId, request);
         }
     }
 

--- a/boot/api/src/test/java/boot/api/com/clip/api/matching/service/UserMatchingReviewServiceTest.java
+++ b/boot/api/src/test/java/boot/api/com/clip/api/matching/service/UserMatchingReviewServiceTest.java
@@ -2,6 +2,7 @@ package boot.api.com.clip.api.matching.service;
 
 import com.clip.ApiApplication;
 import com.clip.api.matching.controller.dto.MatchingReviewDto;
+import com.clip.api.matching.controller.dto.MatchingType;
 import com.clip.api.matching.service.UserMatchingReviewService;
 import com.clip.api.payment.feign.TossPaymentFeign;
 import com.clip.global.config.feign.FeignConfig;
@@ -82,7 +83,7 @@ public class UserMatchingReviewServiceTest {
         String negativePoints = "Negative";
 
         //when
-        userMatchingReviewService.saveMatchingReview(user.getId(), randomMatching.getId(), "RANDOM",
+        userMatchingReviewService.saveMatchingReview(user.getId(), randomMatching.getId(), MatchingType.RANDOM,
                 MatchingReviewDto.builder()
                         .mood(mood)
                         .positivePoints(positivePoints)
@@ -101,30 +102,5 @@ public class UserMatchingReviewServiceTest {
                         RandomMatchingReview::isMemberAllAttended, RandomMatchingReview::getNoShowMembers)
                 .containsExactly(mood, positivePoints, negativePoints, "Review Content", true, "No Show Members");
 
-    }
-
-    @DisplayName("존재하지 않는 매칭 서비스 명으로 리뷰를 작성할 수 없다.")
-    @Test
-    void saveMatchingReviewWithInvalidServiceName() {
-        //given
-        RandomMatching randomMatching = randomMatchingRepository.save(RandomMatching.builder().build());
-        User user = userRepository.save(User.builder().build());
-
-        //when
-        String invalidServiceName = "INVALID_SERVICE_NAME";
-
-        //then
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            userMatchingReviewService.saveMatchingReview(user.getId(), randomMatching.getId(), invalidServiceName,
-                    MatchingReviewDto.builder()
-                            .mood(Mood.NEUTRAL)
-                            .positivePoints("Positive")
-                            .negativePoints("Negative")
-                            .reviewContent("Review Content")
-                            .isMemberAllAttended(true)
-                            .noShowMembers("No Show Members")
-                            .build()
-            );
-        });
     }
 }

--- a/data/core-data/src/main/java/com/clip/matching/entity/UserOneThingMatching.java
+++ b/data/core-data/src/main/java/com/clip/matching/entity/UserOneThingMatching.java
@@ -71,12 +71,12 @@ public class UserOneThingMatching extends BaseEntity {
     private boolean isNoticeRead;
 
     @Column
-    private int lateMinutes;
+    private Integer lateMinutes;
 
     @Builder
     public UserOneThingMatching(User user, OneThingMatching oneThingMatching, OneThingOrder oneThingOrder, OneThingCategory oneThingCategory, String myOneThingContent, String myQuizContent, boolean isCheckedMatchingStart, OneThingDistrict oneThingDistrict,
                                 List<PreferredDate> preferredDates, OneThingBudgetRange oneThingBudgetRange,
-                                OneThingMatchingStatus matchingStatus, boolean isNoticeRead, int lateMinutes) {
+                                OneThingMatchingStatus matchingStatus, boolean isNoticeRead, Integer lateMinutes) {
         this.user = user;
         this.oneThingMatching = oneThingMatching;
         this.oneThingOrder = oneThingOrder;

--- a/data/core-data/src/main/java/com/clip/matching/entity/UserRandomMatching.java
+++ b/data/core-data/src/main/java/com/clip/matching/entity/UserRandomMatching.java
@@ -44,11 +44,11 @@ public class UserRandomMatching extends BaseEntity {
     private boolean isNoticeRead;
 
     @Column
-    private int lateMinutes;
+    private Integer lateMinutes;
 
     @Builder
     public UserRandomMatching(User user, RandomMatching randomMatching, RandomOrder randomOrder, String myOneThingContent, boolean isCheckedMatchingStart,
-                              RandomMatchingStatus matchingStatus, boolean isNoticeRead, int lateMinutes) {
+                              RandomMatchingStatus matchingStatus, boolean isNoticeRead, Integer lateMinutes) {
         this.user = user;
         this.randomMatching = randomMatching;
         this.randomOrder = randomOrder;

--- a/data/core-data/src/main/java/com/clip/matching/repository/UserMatchingRepository.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/UserMatchingRepository.java
@@ -17,6 +17,7 @@ public interface UserMatchingRepository extends JpaRepository<UserOneThingMatchi
     @Query("""
         select new com.clip.matching.repository.projection.MatchingProjectionDto(
             uotm.id,
+            otm.id,
             otm.meetingTime,
             uotm.matchingStatus,
             'ONE_THING',
@@ -36,6 +37,7 @@ public interface UserMatchingRepository extends JpaRepository<UserOneThingMatchi
         
         select new com.clip.matching.repository.projection.MatchingProjectionDto(
             urm.id,
+            rm.id,
             rm.meetingTime,
             urm.matchingStatus,
             'RANDOM',

--- a/data/core-data/src/main/java/com/clip/matching/repository/UserOneThingMatchingRepository.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/UserOneThingMatchingRepository.java
@@ -130,4 +130,12 @@ public interface UserOneThingMatchingRepository extends JpaRepository<UserOneThi
         where u.id = :id
     """)
     Optional<UserOneThingMatching> findByIdWithOneThingMatchingAndUser(@Param("id") long id);
+
+    @Query("""
+        select u
+        from UserOneThingMatching u
+        join fetch u.user
+        where u.oneThingMatching.id = :matchingId
+    """)
+    List<UserOneThingMatching> findRandomMatchingParticipants(@Param("matchingId") long matchingId);
 }

--- a/data/core-data/src/main/java/com/clip/matching/repository/UserRandomMatchingRepository.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/UserRandomMatchingRepository.java
@@ -142,4 +142,12 @@ public interface UserRandomMatchingRepository extends JpaRepository<UserRandomMa
             where u.id = :id
             """)
     Optional<UserRandomMatching> findByIdWithRandomMatchingAndUser(@Param("id") long id);
+
+    @Query("""
+            select u
+            from UserRandomMatching u
+            join fetch u.user
+            where u.randomMatching.id = :matchingId
+            """)
+    List<UserRandomMatching> findRandomMatchingParticipants(@Param("matchingId") long matchingId);
 }

--- a/data/core-data/src/main/java/com/clip/matching/repository/projection/MatchingProjectionDto.java
+++ b/data/core-data/src/main/java/com/clip/matching/repository/projection/MatchingProjectionDto.java
@@ -9,16 +9,18 @@ import java.time.LocalDateTime;
 @Getter
 public class MatchingProjectionDto {
     private Long id;
+    private Long matchingId;
     private LocalDateTime meetingTime;
     private MatchingStatus matchingStatus;
     private String matchingType;
     private String myOneThingContent;
     private Boolean isReviewWritten;
 
-    public MatchingProjectionDto(Long id, LocalDateTime meetingTime, MatchingStatus matchingStatus,
+    public MatchingProjectionDto(Long id, Long matchingId, LocalDateTime meetingTime, MatchingStatus matchingStatus,
                                  String matchingType, String myOneThingContent,
                                  Boolean isReviewWritten) {
         this.id = id;
+        this.matchingId = matchingId;
         this.meetingTime = meetingTime;
         this.matchingStatus = matchingStatus;
         this.matchingType = matchingType;

--- a/data/core-data/src/main/java/com/clip/matching/service/MatchingService.java
+++ b/data/core-data/src/main/java/com/clip/matching/service/MatchingService.java
@@ -137,4 +137,12 @@ public class MatchingService {
     public List<UserRandomMatching> findAllUserRandomMatchingsForNotification(long randomMatchingId) {
         return userRandomMatchingRepository.findAllUserRandomMatchingsForNotification(randomMatchingId);
     }
+
+    public List<UserRandomMatching> findRandomMatchingParticipants(long matchingId) {
+        return userRandomMatchingRepository.findRandomMatchingParticipants(matchingId);
+    }
+
+    public List<UserOneThingMatching> findOneThingMatchingParticipants(long matchingId) {
+        return userOneThingMatchingRepository.findRandomMatchingParticipants(matchingId);
+    }
 }


### PR DESCRIPTION
- 매칭 참여자 리스트 조회 API 구현
- 매칭 후기 작성 API matchingType Enum으로 변경
- 매칭 리스트 조회 API에서 matchingId(OnethingMatching, RandomMatching의 pk)도 받도록 수정 
     - 내 모임을 통해 후기 작성하기로 가는 케이스도 있기 때문에 추가했습니다 -! (후기 작성때는 OnethingMatching, RandomMatching의 pk가 필요)